### PR TITLE
Explicit dependency on ClustForOpt version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["energy", "capacity", "JuMP", "optimization"]
 license = "MIT"
 desc = "Capacity Expansion Problem Formulation for Julia"
 author = ["Elias Kuepper <elias.kuepper@rwth-aachen.de>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -19,3 +19,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 julia = "^1.0"
 JuMP = "^0.19"
+ClustForOpt = "^0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -19,4 +19,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 julia = "^1.0"
 JuMP = "^0.19"
-ClustForOpt = "^0.3"
+ClustForOpt = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -19,4 +19,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 julia = "^1.0"
 JuMP = "^0.19"
-ClustForOpt = "0.3"
+ClustForOpt = "^0.3.4"


### PR DESCRIPTION
Make CapacityExpansion explicitly dependent on ClustForOpt version to reduce issues when introducing breaking changes in ClustForOpt.