### PR TITLE
Hotfix - Capacity dependencies in operational optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["energy", "capacity", "JuMP", "optimization"]
 license = "MIT"
 desc = "Capacity Expansion Problem Formulation for Julia"
 author = ["Elias Kuepper <elias.kuepper@rwth-aachen.de>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/optim_problems/run_opt.jl
+++ b/src/optim_problems/run_opt.jl
@@ -66,7 +66,7 @@ function run_opt(ts_data::ClustData,
   end
   #Setup constraints that bind the capacities of different capacities with each other
   #If design variables are provided, this is already done by the provided variables
-  if haskey(config,"fixed_design_variables")
+  if !haskey(config,"fixed_design_variables")
     setup_opt_intertech_cap!(cep, ts_data, opt_data, config["scale"])
   end
   # Add existing infrastructure to

--- a/src/optim_problems/run_opt.jl
+++ b/src/optim_problems/run_opt.jl
@@ -66,7 +66,7 @@ function run_opt(ts_data::ClustData,
   end
   #Setup constraints that bind the capacities of different capacities with each other
   #If design variables are provided, this is already done by the provided variables
-  if isempty(config["fixed_design_variables"])
+  if haskey(config,"fixed_design_variables")
     setup_opt_intertech_cap!(cep, ts_data, opt_data, config["scale"])
   end
   # Add existing infrastructure to

--- a/src/optim_problems/run_opt.jl
+++ b/src/optim_problems/run_opt.jl
@@ -65,7 +65,10 @@ function run_opt(ts_data::ClustData,
     setup_opt_fix_design_variables!(cep, ts_data, opt_data, config["scale"], config["fixed_design_variables"])
   end
   #Setup constraints that bind the capacities of different capacities with each other
-  setup_opt_intertech_cap!(cep, ts_data, opt_data, config["scale"])
+  #If design variables are provided, this is already done by the provided variables
+  if isempty(config["fixed_design_variables"])
+    setup_opt_intertech_cap!(cep, ts_data, opt_data, config["scale"])
+  end
   # Add existing infrastructure to
   setup_opt_existing_infrastructure!(cep, ts_data, opt_data, config["scale"])
   # Limit the infrastructure expansion


### PR DESCRIPTION
This solves the infeasibility issue I had in the operational optimization with given storage length. 

Issue fixed: If design variables are provided, the constraints on capacity multipliers/equalities are not necessary. Due to rounding errors, they may make the problem infeasible. 