### PR TITLE
Fix broken link to Solvers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ using Pkg
 Pkg.add("CapacityExpansion")
 ```
 
-A solver is required to run an optimization as explained in section [Solver](@ref).
+A solver is required to run an optimization as explained in section [Solver](https://youngfaithful.github.io/CapacityExpansion.jl/stable/opt_cep/#Solver-1).
 Install e.g.:
 ```julia
 using Pkg


### PR DESCRIPTION
Found a broken link in the README. I think it meant to link to the Solvers section in the documentation so I updated it.

X-Ref: https://github.com/openjournals/joss-reviews/issues/2034